### PR TITLE
Fix UI not updating when cancel/mark/unmark commands are entered

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CancelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CancelCommand.java
@@ -57,6 +57,7 @@ public class CancelCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX);
         }
         Appointment cancelledAppt = patientToCancelAppt.cancelAppointment(apptIndex.getZeroBased());
+        model.refreshPerson(patientToCancelAppt);
 
         return new CommandResult(MESSAGE_CANCEL_APPOINTMENT_SUCCESS + patientToCancelAppt.getName());
     }

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -4,6 +4,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Appointment;
+import seedu.address.model.person.Person;
 
 /**
  * Marks an appointment for the given patient as complete.
@@ -32,6 +33,7 @@ public class MarkCommand extends SelectAppointmentCommand {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        Person personToMark = getTargetPerson(model);
         Appointment appointmentToMark = getTargetAppointment(model);
 
         if (appointmentToMark.isMarked()) {
@@ -39,6 +41,7 @@ public class MarkCommand extends SelectAppointmentCommand {
         }
 
         appointmentToMark.mark();
+        model.refreshPerson(personToMark);
         return new CommandResult(String.format(MESSAGE_MARK_PERSON_SUCCESS,
                 indexOfAppointment.getOneBased(),
                 getTargetPerson(model).getName()));

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -4,6 +4,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Appointment;
+import seedu.address.model.person.Person;
 
 /**
  * Unmarks an appointment for the given patient as incomplete.
@@ -32,6 +33,7 @@ public class UnmarkCommand extends SelectAppointmentCommand {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        Person personToMark = getTargetPerson(model);
         Appointment appointmentToUnmark = getTargetAppointment(model);
 
         if (!appointmentToUnmark.isMarked()) {
@@ -39,6 +41,7 @@ public class UnmarkCommand extends SelectAppointmentCommand {
         }
 
         appointmentToUnmark.unmark();
+        model.refreshPerson(personToMark);
         return new CommandResult(String.format(MESSAGE_UNMARK_PERSON_SUCCESS,
                 indexOfAppointment.getOneBased(),
                 getTargetPerson(model).getName()));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -86,6 +86,13 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Refreshes the given person {@code target}, forcing the app to visually show any updated changes back to the user.
+     */
+    public void refreshPerson(Person target) {
+        persons.setPerson(target, target);
+    }
+
+    /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -76,6 +76,12 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Refreshes the given person {@code target}, forcing the app to visually show any updated changes back to the user.
+     * {@code target} must exist in the address book.
+     */
+    void refreshPerson(Person target);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -111,6 +111,13 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public void refreshPerson(Person target) {
+        requireNonNull(target);
+
+        addressBook.refreshPerson(target);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -139,6 +139,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void refreshPerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Closes #73 

Often when such commands are entered, the UI does not visually update to reflect the change, though the data within is indeed already changed. This pr fixes that.