### PR TITLE
Make `find` command filter appointment list as well

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,6 +13,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX =
             "The appointment index provided is invalid";
 
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_RESULTS_LISTED_OVERVIEW = "%1$d persons and %2$d appointments listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,12 +2,16 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.AppointmentOfFilteredPersonsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons and their appointments in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
@@ -15,7 +19,8 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "the specified keywords (case-insensitive) and displays them and their appointments as 2 lists with "
+            + "index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
@@ -28,9 +33,18 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
         model.updateFilteredPersonList(predicate);
+
+        List<Person> validPersons = model.getFilteredPersonList();
+        AppointmentOfFilteredPersonsPredicate appointmentPredicate =
+                new AppointmentOfFilteredPersonsPredicate(validPersons);
+        model.updateFilteredAppointmentList(appointmentPredicate);
+
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_RESULTS_LISTED_OVERVIEW,
+                        model.getFilteredPersonList().size(),
+                        model.getFilteredAppointmentList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Appointment.java
+++ b/src/main/java/seedu/address/model/person/Appointment.java
@@ -124,6 +124,10 @@ public class Appointment {
         this.patient = patient;
     }
 
+    public Person getPatient() {
+        return patient;
+    }
+
     public String getPatientName() {
         return this.patient.getName().fullName;
     }

--- a/src/main/java/seedu/address/model/person/AppointmentOfFilteredPersonsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AppointmentOfFilteredPersonsPredicate.java
@@ -1,0 +1,28 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Appointment}'s {@code Patient} matches any of the Persons given.
+ */
+public class AppointmentOfFilteredPersonsPredicate implements Predicate<Appointment> {
+    private final List<Person> filteredPersons;
+
+    public AppointmentOfFilteredPersonsPredicate(List<Person> filteredPersons) {
+        this.filteredPersons = filteredPersons;
+    }
+
+    @Override
+    public boolean test(Appointment appointment) {
+        return filteredPersons.stream().anyMatch(validPersons -> validPersons.equals(appointment.getPatient()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AppointmentOfFilteredPersonsPredicate // instanceof handles nulls
+                && filteredPersons.equals((
+                        (AppointmentOfFilteredPersonsPredicate) other).filteredPersons)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/AppointmentOfFilteredPersonsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AppointmentOfFilteredPersonsPredicate.java
@@ -20,9 +20,15 @@ public class AppointmentOfFilteredPersonsPredicate implements Predicate<Appointm
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AppointmentOfFilteredPersonsPredicate // instanceof handles nulls
-                && filteredPersons.equals((
-                        (AppointmentOfFilteredPersonsPredicate) other).filteredPersons)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AppointmentOfFilteredPersonsPredicate)) {
+            return false;
+        }
+
+        AppointmentOfFilteredPersonsPredicate otherPredicate = (AppointmentOfFilteredPersonsPredicate) other;
+        return filteredPersons.equals(otherPredicate.filteredPersons);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,8 +3,9 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.commons.core.Messages.MESSAGE_RESULTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
@@ -12,13 +13,16 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AppointmentOfFilteredPersonsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -56,22 +60,34 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_RESULTS_LISTED_OVERVIEW, 0, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
+
         expectedModel.updateFilteredPersonList(predicate);
+        List<Person> validPersons = expectedModel.getFilteredPersonList();
+        AppointmentOfFilteredPersonsPredicate appointmentPredicate =
+                new AppointmentOfFilteredPersonsPredicate(validPersons);
+        expectedModel.updateFilteredAppointmentList(appointmentPredicate);
+
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        String expectedMessage = String.format(MESSAGE_RESULTS_LISTED_OVERVIEW, 4, 3);
+        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz Benson");
         FindCommand command = new FindCommand(predicate);
+
         expectedModel.updateFilteredPersonList(predicate);
+        List<Person> validPersons = expectedModel.getFilteredPersonList();
+        AppointmentOfFilteredPersonsPredicate appointmentPredicate =
+                new AppointmentOfFilteredPersonsPredicate(validPersons);
+        expectedModel.updateFilteredAppointmentList(appointmentPredicate);
+
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(BENSON, CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
     /**


### PR DESCRIPTION
Currently, `find` does not filter the appointment list at all. This PR fixes that.

This PR does not add any new functionality to the `find` command.