### PR TITLE
Add ability to `list all` patients and appointments simultaneously

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,11 +59,12 @@ Examples:
 
 ### Listing all patients/appointments : `list`
 
-Shows a list of all patients or appointments, depending on the parameter given.
+Shows a list of all patients and/or appointments, depending on the parameter given.
 
 Format:
 * `list patients`
 * `list appts`
+* `list all`
 
 
 ### Editing a patient : `edit patients`

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,7 +11,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String INCOMPLETE_COMMAND = "Command is incomplete, specify either "
-            + "appts or patients behind the command word";
+            + "'appts' or 'patients' behind the command word";
+    public static final String INCOMPLETE_LIST_COMMAND = "Command is incomplete, specify either "
+            + "'appts', 'patients' or 'all' behind the command word";
     public static final String START_DATE_AFTER_END_DATE = "The start date entered should not be after the end date!";
 
     public static final String MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX =

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -16,9 +16,11 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS_PATIENTS = "Listed all patients.";
     public static final String MESSAGE_SUCCESS_APPOINTMENTS = "Listed all appointments.";
+    public static final String MESSAGE_SUCCESS_ALL = "Listed all patients and appointments";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " patients: List down all patients.\n"
-            + COMMAND_WORD + " appts: List down all appointments.\n";
+            + COMMAND_WORD + " appts: List down all appointments.\n"
+            + COMMAND_WORD + " all: List down all patients and appointments\n";
 
     private final String type;
 
@@ -29,16 +31,24 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        if (this.type.equals("patients")) {
-            requireNonNull(model);
+        requireNonNull(model);
+        switch (type) {
+        case "all":
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
+            HiddenPredicateSingleton.clearHiddenAll();
+            return new CommandResult(MESSAGE_SUCCESS_ALL);
+        case "patients":
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             HiddenPredicateSingleton.clearHiddenPatients();
             return new CommandResult(MESSAGE_SUCCESS_PATIENTS);
-        } else {
-            requireNonNull(model);
+        case "appts":
             model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
             HiddenPredicateSingleton.clearHiddenAppts();
             return new CommandResult(MESSAGE_SUCCESS_APPOINTMENTS);
+        default:
+            assert false : "Input should be either all, patients, appt; shouldn't reach here";
+            return null;
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -16,7 +16,7 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS_PATIENTS = "Listed all patients.";
     public static final String MESSAGE_SUCCESS_APPOINTMENTS = "Listed all appointments.";
-    public static final String MESSAGE_SUCCESS_ALL = "Listed all patients and appointments";
+    public static final String MESSAGE_SUCCESS_ALL = "Listed all patients and appointments.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " patients: List down all patients.\n"
             + COMMAND_WORD + " appts: List down all appointments.\n"

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -47,8 +47,8 @@ public class ListCommand extends Command {
             HiddenPredicateSingleton.clearHiddenAppts();
             return new CommandResult(MESSAGE_SUCCESS_APPOINTMENTS);
         default:
-            assert false : "Input should be either all, patients, appt; shouldn't reach here";
-            return null;
+            assert false : "Input should be either 'all', 'patients' or 'appt'; shouldn't reach here";
+            return new CommandResult("Unrecognised list keyword");
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -35,7 +35,7 @@ public class AddressBookParser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)"
-            + "(?<descriptor>(?i:\\s+appts|\\s+patients)?)(?<arguments>.*)");
+            + "(?<descriptor>(?i:\\s+appts|\\s+patients|\\s+all)?)(?<arguments>.*)");
 
     private final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.INCOMPLETE_COMMAND;
+import static seedu.address.commons.core.Messages.INCOMPLETE_LIST_COMMAND;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -106,7 +107,7 @@ public class AddressBookParser {
             } else if (!arguments.isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
             } else {
-                throw new ParseException(INCOMPLETE_COMMAND);
+                throw new ParseException(INCOMPLETE_LIST_COMMAND);
             }
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/model/person/HiddenPredicateSingleton.java
+++ b/src/main/java/seedu/address/model/person/HiddenPredicateSingleton.java
@@ -88,6 +88,14 @@ public class HiddenPredicateSingleton implements Predicate<Person> {
         hiddenAppts.clear();
     }
 
+    /**
+     * Resets the list of hidden patients and appointments to empty.
+     */
+    public static void clearHiddenAll() {
+        clearHiddenPatients();
+        clearHiddenAppts();
+    }
+
     public static Predicate<Appointment> getCurrApptPredicate() {
         return currApptPredicate;
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.person.Appointment;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -135,7 +136,7 @@ public class CommandTestUtil {
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
     /**
-     * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
+     * Updates {@code model}'s filtered person list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
@@ -148,4 +149,16 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered appointment list to show only the appointment at the given {@code targetIndex}
+     * in the {@code model}'s address book.
+     */
+    public static void showAppointmentAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredAppointmentList().size());
+
+        Appointment appointmentToShow = model.getFilteredAppointmentList().get(targetIndex.getZeroBased());
+        model.updateFilteredAppointmentList(appointment -> appointment.isSameAppointment(appointmentToShow));
+
+        assertEquals(1, model.getFilteredAppointmentList().size());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showAppointmentAtIndex;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_APPOINTMENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -43,5 +46,26 @@ public class ListCommandTest {
     public void execute_appointmentListIsNotFiltered_showsSameList() {
         assertCommandSuccess(
                 new ListCommand("appts"), model, ListCommand.MESSAGE_SUCCESS_APPOINTMENTS, expectedModel);
+    }
+
+    @Test
+    public void execute_appointmentListIsFiltered_showsEverything() {
+        showAppointmentAtIndex(model, INDEX_FIRST_APPOINTMENT);
+        assertCommandSuccess(
+                new ListCommand("appts"), model, ListCommand.MESSAGE_SUCCESS_APPOINTMENTS, expectedModel);
+    }
+
+    @Test
+    public void execute_patientAndAppointmentListIsNotFiltered_showsSameList() {
+        assertCommandSuccess(
+                new ListCommand("all"), model, ListCommand.MESSAGE_SUCCESS_ALL, expectedModel);
+    }
+
+    @Test
+    public void execute_patientAndAppointmentListIsFiltered_showsEverything() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showAppointmentAtIndex(model, INDEX_FIRST_APPOINTMENT);
+        assertCommandSuccess(
+                new ListCommand("all"), model, ListCommand.MESSAGE_SUCCESS_ALL, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.CommandTestUtil.showAppointmentAtInde
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_APPOINTMENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Closes #144 

Instead of doing `list patients` and `list appts` to display everything, you can now do `list all` instead.