### PR TITLE
Add new command `list all` to show all patients and appointments at the same time

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -16,6 +16,7 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS_PATIENTS = "Listed all patients.";
     public static final String MESSAGE_SUCCESS_APPOINTMENTS = "Listed all appointments.";
+    public static final String MESSAGE_SUCCESS_ALL = "Listed all patients and appointments.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " patients: List down all patients.\n"
             + COMMAND_WORD + " appts: List down all appointments.\n";
@@ -29,16 +30,21 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
+        requireNonNull(model);
         if (this.type.equals("patients")) {
-            requireNonNull(model);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             HiddenPredicateSingleton.clearHiddenPatients();
             return new CommandResult(MESSAGE_SUCCESS_PATIENTS);
-        } else {
-            requireNonNull(model);
+        } else if (this.type.equals("appts")) {
             model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
             HiddenPredicateSingleton.clearHiddenAppts();
             return new CommandResult(MESSAGE_SUCCESS_APPOINTMENTS);
+        } else {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            HiddenPredicateSingleton.clearHiddenPatients();
+            model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
+            HiddenPredicateSingleton.clearHiddenAppts();
+            return new CommandResult(MESSAGE_SUCCESS_ALL);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -35,7 +35,7 @@ public class AddressBookParser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)"
-            + "(?<descriptor>(?i:\\s+appts|\\s+patients)?)(?<arguments>.*)");
+            + "(?<descriptor>(?i:\\s+appts|\\s+patients|\\s+all)?)(?<arguments>.*)");
 
     private final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 


### PR DESCRIPTION
`list patients` and `list appts` will list out all patients and all appointments respectively.

This can be time-consuming and inefficient to do one at a time if the user wants to view everything again.

We add a new command `list all` to fix this.