### PR TITLE
Fix minor find unhide bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -103,8 +103,9 @@ public class FindCommand extends Command {
 
         Predicate<Person> combinedPersonPredicate = HiddenPredicateSingleton
                 .combineWithRegularPredicate(personFulfillingBothPredicates);
-        Predicate<Appointment> combinedApptPredicate = HiddenPredicateSingleton
-                .combineWithRegularApptPredicate(appointmentFulfillingBothPredicates);
+        Predicate<Appointment> combinedApptPredicate = !isUsingAppointmentPredicate
+                ? appointmentFulfillingBothPredicates.and(HiddenPredicateSingleton.getCurrApptPredicate())
+                : HiddenPredicateSingleton.combineWithRegularApptPredicate(appointmentFulfillingBothPredicates);
 
         model.updateFilteredPersonList(combinedPersonPredicate);
         model.updateFilteredAppointmentList(combinedApptPredicate);

--- a/src/main/java/seedu/address/logic/commands/UnhidePatientsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnhidePatientsCommand.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.Appointment;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.AppointmentOfFilteredPersonsPredicate;
 import seedu.address.model.person.predicates.HiddenPredicateSingleton;
@@ -44,7 +45,9 @@ public class UnhidePatientsCommand extends Command {
         List<Person> validPersons = model.getFilteredPersonList();
         AppointmentOfFilteredPersonsPredicate appointmentPredicate =
                 new AppointmentOfFilteredPersonsPredicate(validPersons);
-        model.updateFilteredAppointmentList(appointmentPredicate);
+        Predicate<Appointment> updatedPredicate =
+                appointmentPredicate.and(HiddenPredicateSingleton.getCurrApptPredicate());
+        model.updateFilteredAppointmentList(updatedPredicate);
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_RESULTS_LISTED_OVERVIEW,

--- a/src/main/java/seedu/address/model/person/predicates/HideAppointmentPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/HideAppointmentPredicate.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Appointment;
 import seedu.address.model.tag.Tag;
 
@@ -38,7 +39,7 @@ public class HideAppointmentPredicate implements Predicate<Appointment> {
         switch (condition) {
         case KEYWORD:
             passed = keywords.stream()
-                    .anyMatch(keyword -> appt.getReason().contains(keyword));
+                    .anyMatch(keyword -> StringUtil.containsIgnoreCase(appt.getReason(), keyword));
             break;
         case TAG:
             Set<Tag> tags = appt.getTags();


### PR DESCRIPTION
Fixes this bug:

1. Start with sample address book
2. `find ta/throat`
3. `hide patients n/david`
4. `unhide patients n/david`, and an appointment with tag nose shows up

Also makes hide appointment by reason case insensitive.

Also fixes the app not showing any results when doing a find patient command followed by a find appointment command
E.g(`find n/david` then `find r/covid`)