### PR TITLE
Improve code quality and fix bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -63,18 +63,17 @@ public class AddressBookParser {
         final String commandWord = matcher.group("commandWord").toLowerCase();
         final String descriptor = matcher.group("descriptor").trim().toLowerCase();
         final String arguments = matcher.group("arguments");
-        final String descriptorAndArguments = descriptor + arguments;
         logger.info(descriptor);
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(descriptorAndArguments);
+            return new AddCommandParser().parse(arguments);
 
         case EditPatientCommand.COMMAND_WORD:
             return parseEditPatientCommand(descriptor, arguments);
 
         case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(descriptorAndArguments);
+            return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
@@ -86,7 +85,7 @@ public class AddressBookParser {
             return parseUngroupCommand(descriptor, arguments);
 
         case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(descriptorAndArguments);
+            return new FindCommandParser().parse(arguments);
 
         case HidePatientsCommand.COMMAND_WORD:
             return parseHidePatientsCommand(descriptor, arguments);
@@ -95,16 +94,16 @@ public class AddressBookParser {
             return parseUnhidePatientsCommand(descriptor, arguments);
 
         case BookCommand.COMMAND_WORD:
-            return new BookCommandParser().parse(descriptorAndArguments);
+            return new BookCommandParser().parse(arguments);
 
         case CancelCommand.COMMAND_WORD:
-            return new CancelCommandParser().parse(descriptorAndArguments);
+            return new CancelCommandParser().parse(arguments);
 
         case MarkCommand.COMMAND_WORD:
-            return new MarkCommandParser().parse(descriptorAndArguments);
+            return new MarkCommandParser().parse(arguments);
 
         case UnmarkCommand.COMMAND_WORD:
-            return new UnmarkCommandParser().parse(descriptorAndArguments);
+            return new UnmarkCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return parseListCommand(descriptor, arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -63,17 +63,18 @@ public class AddressBookParser {
         final String commandWord = matcher.group("commandWord").toLowerCase();
         final String descriptor = matcher.group("descriptor").trim().toLowerCase();
         final String arguments = matcher.group("arguments");
+        final String descriptorAndArguments = descriptor + arguments;
         logger.info(descriptor);
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            return new AddCommandParser().parse(descriptorAndArguments);
 
         case EditPatientCommand.COMMAND_WORD:
             return parseEditPatientCommand(descriptor, arguments);
 
         case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+            return new DeleteCommandParser().parse(descriptorAndArguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
@@ -85,7 +86,7 @@ public class AddressBookParser {
             return parseUngroupCommand(descriptor, arguments);
 
         case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+            return new FindCommandParser().parse(descriptorAndArguments);
 
         case HidePatientsCommand.COMMAND_WORD:
             return parseHidePatientsCommand(descriptor, arguments);
@@ -94,16 +95,16 @@ public class AddressBookParser {
             return parseUnhidePatientsCommand(descriptor, arguments);
 
         case BookCommand.COMMAND_WORD:
-            return new BookCommandParser().parse(arguments);
+            return new BookCommandParser().parse(descriptorAndArguments);
 
         case CancelCommand.COMMAND_WORD:
-            return new CancelCommandParser().parse(arguments);
+            return new CancelCommandParser().parse(descriptorAndArguments);
 
         case MarkCommand.COMMAND_WORD:
-            return new MarkCommandParser().parse(arguments);
+            return new MarkCommandParser().parse(descriptorAndArguments);
 
         case UnmarkCommand.COMMAND_WORD:
-            return new UnmarkCommandParser().parse(arguments);
+            return new UnmarkCommandParser().parse(descriptorAndArguments);
 
         case ListCommand.COMMAND_WORD:
             return parseListCommand(descriptor, arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -70,13 +70,7 @@ public class AddressBookParser {
             return new AddCommandParser().parse(arguments);
 
         case EditPatientCommand.COMMAND_WORD:
-            if (descriptor.equals(EditPatientCommand.DESCRIPTOR_WORD)) {
-                return new EditPatientCommandParser().parse(arguments);
-            } else if (descriptor.equals(EditAppointmentCommand.DESCRIPTOR_WORD)) {
-                return new EditAppointmentCommandParser().parse(arguments);
-            } else {
-                throw new ParseException(INCOMPLETE_COMMAND);
-            }
+            return parseEditPatientCommand(descriptor, arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
@@ -85,43 +79,20 @@ public class AddressBookParser {
             return new ClearCommand();
 
         case GroupPatientCommand.COMMAND_WORD:
-            if (descriptor.equals(GroupPatientCommand.DESCRIPTOR_WORD)) {
-                return new GroupPatientCommand();
-            } else if (descriptor.equals(GroupAppointmentCommand.DESCRIPTOR_WORD)) {
-                return new GroupAppointmentCommandParser().parse(arguments);
-            } else {
-                throw new ParseException(INCOMPLETE_COMMAND);
-            }
+            return parseGroupPatientCommand(descriptor, arguments);
 
         case UngroupCommand.COMMAND_WORD:
-            if (!descriptor.isEmpty()) {
-                return new UngroupCommand(descriptor);
-            } else if (!arguments.isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UngroupCommand.MESSAGE_USAGE));
-            } else {
-                throw new ParseException(INCOMPLETE_COMMAND);
-            }
+            return parseUngroupCommand(descriptor, arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
         case HidePatientsCommand.COMMAND_WORD:
-            if (descriptor.equals(HidePatientsCommand.DESCRIPTOR_WORD)) {
-                return new HidePatientsCommandParser().parse(arguments);
-            } else if (descriptor.equals(HideAppointmentsCommand.DESCRIPTOR_WORD)) {
-                return new HideAppointmentsCommandParser().parse(arguments);
-            } else {
-                throw new ParseException(INCOMPLETE_COMMAND);
-            }
+            return parseHidePatientsCommand(descriptor, arguments);
 
         case UnhidePatientsCommand.COMMAND_WORD:
-            if (descriptor.equals(UnhidePatientsCommand.DESCRIPTOR_WORD)) {
-                return new UnhidePatientsCommandParser().parse(arguments);
-            } else if (descriptor.equals(UnhideAppointmentsCommand.DESCRIPTOR_WORD)) {
-                return new UnhideAppointmentsCommandParser().parse(arguments);
-            } else {
-                throw new ParseException(INCOMPLETE_COMMAND);
-            }
+            return parseUnhidePatientsCommand(descriptor, arguments);
+
         case BookCommand.COMMAND_WORD:
             return new BookCommandParser().parse(arguments);
 
@@ -135,13 +106,7 @@ public class AddressBookParser {
             return new UnmarkCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            if (!descriptor.isEmpty()) {
-                return new ListCommand(descriptor);
-            } else if (!arguments.isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
-            } else {
-                throw new ParseException(INCOMPLETE_LIST_COMMAND);
-            }
+            return parseListCommand(descriptor, arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -154,4 +119,63 @@ public class AddressBookParser {
         }
     }
 
+    private Command parseEditPatientCommand(String descriptor, String arguments) throws ParseException {
+        if (descriptor.equals(EditPatientCommand.DESCRIPTOR_WORD)) {
+            return new EditPatientCommandParser().parse(arguments);
+        } else if (descriptor.equals(EditAppointmentCommand.DESCRIPTOR_WORD)) {
+            return new EditAppointmentCommandParser().parse(arguments);
+        } else {
+            throw new ParseException(INCOMPLETE_COMMAND);
+        }
+    }
+
+    private Command parseGroupPatientCommand(String descriptor, String arguments) throws ParseException {
+        if (descriptor.equals(GroupPatientCommand.DESCRIPTOR_WORD)) {
+            return new GroupPatientCommand();
+        } else if (descriptor.equals(GroupAppointmentCommand.DESCRIPTOR_WORD)) {
+            return new GroupAppointmentCommandParser().parse(arguments);
+        } else {
+            throw new ParseException(INCOMPLETE_COMMAND);
+        }
+    }
+
+    private UngroupCommand parseUngroupCommand(String descriptor, String arguments) throws ParseException {
+        if (!descriptor.isEmpty()) {
+            return new UngroupCommand(descriptor);
+        } else if (!arguments.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UngroupCommand.MESSAGE_USAGE));
+        } else {
+            throw new ParseException(INCOMPLETE_COMMAND);
+        }
+    }
+
+    private Command parseHidePatientsCommand(String descriptor, String arguments) throws ParseException {
+        if (descriptor.equals(HidePatientsCommand.DESCRIPTOR_WORD)) {
+            return new HidePatientsCommandParser().parse(arguments);
+        } else if (descriptor.equals(HideAppointmentsCommand.DESCRIPTOR_WORD)) {
+            return new HideAppointmentsCommandParser().parse(arguments);
+        } else {
+            throw new ParseException(INCOMPLETE_COMMAND);
+        }
+    }
+
+    private Command parseUnhidePatientsCommand(String descriptor, String arguments) throws ParseException {
+        if (descriptor.equals(UnhidePatientsCommand.DESCRIPTOR_WORD)) {
+            return new UnhidePatientsCommandParser().parse(arguments);
+        } else if (descriptor.equals(UnhideAppointmentsCommand.DESCRIPTOR_WORD)) {
+            return new UnhideAppointmentsCommandParser().parse(arguments);
+        } else {
+            throw new ParseException(INCOMPLETE_COMMAND);
+        }
+    }
+
+    private ListCommand parseListCommand(String descriptor, String arguments) throws ParseException {
+        if (!descriptor.isEmpty()) {
+            return new ListCommand(descriptor);
+        } else if (!arguments.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        } else {
+            throw new ParseException(INCOMPLETE_LIST_COMMAND);
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -79,7 +79,7 @@ public class AddressBookParser {
             return new ClearCommand();
 
         case GroupPatientCommand.COMMAND_WORD:
-            return parseGroupPatientCommand(descriptor, arguments);
+            return parseGroupCommand(descriptor, arguments);
 
         case UngroupCommand.COMMAND_WORD:
             return parseUngroupCommand(descriptor, arguments);
@@ -129,7 +129,7 @@ public class AddressBookParser {
         }
     }
 
-    private Command parseGroupPatientCommand(String descriptor, String arguments) throws ParseException {
+    private Command parseGroupCommand(String descriptor, String arguments) throws ParseException {
         if (descriptor.equals(GroupPatientCommand.DESCRIPTOR_WORD)) {
             return new GroupPatientCommand();
         } else if (descriptor.equals(GroupAppointmentCommand.DESCRIPTOR_WORD)) {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -69,7 +69,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         CombinedAppointmentPredicate combinedAppointmentPredicate =
                 new CombinedAppointmentPredicate(reason, parsedStartDateTime, parsedEndDateTime, appointmentTagList);
 
-        boolean isUsingAppointmentPredicate = isAnyAppointmentFieldSpecified(reason, startDateTime, endDateTime, appointmentTagList);
+        boolean isUsingAppointmentPredicate =
+                isAnyAppointmentFieldSpecified(reason, startDateTime, endDateTime, appointmentTagList);
 
         return new FindCommand(combinedPersonPredicate, combinedAppointmentPredicate, isUsingAppointmentPredicate);
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -59,12 +59,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                 name, phone, email, address, reason, startDateTime, endDateTime);
         checkIfInputsValid(name, phone, personTagList, startDateTime, endDateTime);
 
-        LocalDateTime parsedStartDateTime = startDateTime.isEmpty()
-                ? LocalDateTime.MIN
-                : LocalDateTime.parse(startDateTime, Appointment.DATE_FORMATTER);
-        LocalDateTime parsedEndDateTime = endDateTime.isEmpty()
-                ? LocalDateTime.MAX
-                : LocalDateTime.parse(endDateTime, Appointment.DATE_FORMATTER);
+        LocalDateTime parsedStartDateTime = parseDateTime(startDateTime, LocalDateTime.MIN);
+        LocalDateTime parsedEndDateTime = parseDateTime(endDateTime, LocalDateTime.MAX);
 
         checkIfStartDateIsBeforeEndDate(parsedStartDateTime, parsedEndDateTime);
 
@@ -73,11 +69,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         CombinedAppointmentPredicate combinedAppointmentPredicate =
                 new CombinedAppointmentPredicate(reason, parsedStartDateTime, parsedEndDateTime, appointmentTagList);
 
-        boolean isAnyAppointmentFieldSpecified =
-                !reason.isEmpty() || !startDateTime.isEmpty() || !endDateTime.isEmpty()
-                        || !appointmentTagList.isEmpty();
+        boolean isUsingAppointmentPredicate = isAnyAppointmentFieldSpecified(reason, startDateTime, endDateTime, appointmentTagList);
 
-        return new FindCommand(combinedPersonPredicate, combinedAppointmentPredicate, isAnyAppointmentFieldSpecified);
+        return new FindCommand(combinedPersonPredicate, combinedAppointmentPredicate, isUsingAppointmentPredicate);
     }
 
     private void checkIfAtLeastOneInputPresent(List<String> personTagList, List<String> appointmentTagList,
@@ -119,10 +113,23 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
     }
 
+    private LocalDateTime parseDateTime(String startDateTime, LocalDateTime defaultValue) {
+        return startDateTime.isEmpty()
+                ? defaultValue
+                : LocalDateTime.parse(startDateTime, Appointment.DATE_FORMATTER);
+    }
+
     private void checkIfStartDateIsBeforeEndDate(LocalDateTime parsedStartDateTime,
                                                  LocalDateTime parsedEndDateTime) throws ParseException {
         if (parsedStartDateTime.isAfter(parsedEndDateTime)) {
             throw new ParseException(Messages.START_DATE_AFTER_END_DATE);
         }
+    }
+
+    private boolean isAnyAppointmentFieldSpecified(String reason, String startDateTime, String endDateTime,
+                                                   List<String> appointmentTagList) {
+        boolean isAllAppointmentFieldsEmpty = !reason.isEmpty() || !startDateTime.isEmpty()
+                || !endDateTime.isEmpty() || !appointmentTagList.isEmpty();
+        return isAllAppointmentFieldsEmpty;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SelectAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectAppointmentCommandParser.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.SelectAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -23,10 +21,8 @@ public abstract class SelectAppointmentCommandParser<T extends SelectAppointment
      */
     protected Index getAppointmentIndex(String args) throws ParseException {
         requireNonNull(args);
-        List<Index> indexList;
-        int expectedIndexCount = 1;
 
-        indexList = ParserUtil.parseIndexes(args, expectedIndexCount);
-        return indexList.get(0);
+        Index index = ParserUtil.parseIndex(args);
+        return index;
     }
 }


### PR DESCRIPTION
Changes
- Change `SelectAppointmentParser` to use the 1 index parse index of `parseIndexes`
- Reduce method length of `parse` in `FindCommandParser` and improve slap
- Extracted out if else block in `parseCommand` in `AddressBookParser`

- **Fixed a bug where you can do commands like `mark patients 1`, `delete all 1` and it'll work as if the patients/all isn't there**